### PR TITLE
Fix argtable by renaming and fixing download link

### DIFF
--- a/argtable/PSPBUILD
+++ b/argtable/PSPBUILD
@@ -25,7 +25,7 @@ package() {
     cd "${pkgname}2-13/build"
     make --quiet $MAKEFLAGS install
     # I don't know why header is not being copied
-    install -m 644 ../src/argtable2.h "$pkgdir/psp/include/" 
+    install -m 644 ../src/argtable2.h "$pkgdir/psp/include/argtable2.h" 
     cd ..
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"

--- a/argtable/PSPBUILD
+++ b/argtable/PSPBUILD
@@ -25,7 +25,7 @@ package() {
     cd "${pkgname}2-13/build"
     make --quiet $MAKEFLAGS install
     # I don't know why header is not being copied
-    install -m 644 ../src/argtable2.h "$pkgdir/psp/include" 
+    install -m 644 ../src/argtable2.h "$pkgdir/psp/include/" 
     cd ..
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"

--- a/argtable/PSPBUILD
+++ b/argtable/PSPBUILD
@@ -25,7 +25,8 @@ package() {
     cd "${pkgname}2-13/build"
     make --quiet $MAKEFLAGS install
     # I don't know why header is not being copied
-    install -m 644 ../src/argtable2.h "$pkgdir/psp/include/argtable2.h" 
+    mkdir -m 755 -p "$pkgdir/psp/include"
+    install -m 644 ../src/argtable2.h "$pkgdir/psp/include/" 
     cd ..
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"

--- a/argtable/PSPBUILD
+++ b/argtable/PSPBUILD
@@ -1,4 +1,4 @@
-pkgname=libargtable
+pkgname=argtable
 pkgver=2.13
 pkgrel=1
 pkgdesc="Argtable is an ANSI C library for parsing GNU style command line options with a minimum of fuss."
@@ -8,12 +8,12 @@ license=()
 depends=()
 makedepends=()
 optdepends=()
-source=("git+https://downloads.sourceforge.net/${pkgname}/${pkgname}-${pkgver}.tar.gz")
-sha256sums=('SKIP')
+source=("http://prdownloads.sourceforge.net/${pkgname}/${pkgname}2-13.tar.gz")
+sha256sums=('8f77e8a7ced5301af6e22f47302fdbc3b1ff41f2b83c43c77ae5ca041771ddbf')
 
 
 build() {
-    cd "$pkgname-$pkgver"
+    cd "${pkgname}2-13"
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
@@ -22,7 +22,7 @@ build() {
 }
 
 package() {
-    cd "$pkgname-$pkgver/build"
+    cd "${pkgname}2-13/build"
     make --quiet $MAKEFLAGS install
     # I don't know why header is not being copied
     install -m 644 ../src/argtable2.h "$pkgdir/psp/include" 
@@ -31,4 +31,3 @@ package() {
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
     install -m 644 COPYING "$pkgdir/psp/share/licenses/$pkgname"
 }
-


### PR DESCRIPTION
The versioning in the filename is weird. You might also want to use psp-cmake instead of cmake with a toolchain file. Looks a bit cleaner.